### PR TITLE
Fix ES module version

### DIFF
--- a/stockpile-wrapper/requirements.txt
+++ b/stockpile-wrapper/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch >= 7.9
+elasticsearch < 7.14.0
 elasticsearch_dsl
 kubernetes < 12.0
 openshift


### PR DESCRIPTION
### Description

To prevent issues like:

```
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/fs-drift] RUN STATUS DONE
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Input dictionary is empty for module ocp_default_ingress_controller
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Input dictionary is empty for module ocp_dns
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Input dictionary is empty for module ocp_kube_apiserver
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Input dictionary is empty for module ocp_kube_controllermanager
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Input dictionary is empty for module ocp_network_operator
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Unknown indexing error: The client noticed that the server is not a supported distribution of Elasticsearch
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Indexing exception found The client noticed that the server is not a supported distribution of Elasticsearch
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Closing Redis connection
[pod/fs-drift-benchmark-client-3f5a0b88-1-5xlqb/backpack] Attempting to close ES connection
```